### PR TITLE
Updated utils version to v0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "@lulibrary/lag-utils": {
-      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#a95a6ccb9b89a37c20943586e26de4abaf2a2ec2",
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#7ed837b0bccc5a28dc3b735ec200184f19ea3b88",
       "requires": {
         "aws-sdk": "2.224.1",
         "eslint-plugin-mocha": "5.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sinon-chai": "^3.0.0"
   },
   "dependencies": {
-    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.2.0",
+    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.1",
     "lodash.merge": "^4.6.1",
     "lodash.pick": "^4.4.0",
     "moment": "^2.22.1"


### PR DESCRIPTION
This updates the version of the LAG-Utils dependency to the current latest version, v0.3.1