### PR TITLE
Add Request class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
-module.exports = {}
+module.exports = {
+  Request: require('./request')
+}

--- a/src/request.js
+++ b/src/request.js
@@ -1,8 +1,3 @@
-const _pick = require('lodash.pick')
-const moment = require('moment')
-const _merge = require('lodash.merge')
-const DB = require('@lulibrary/lag-utils').DB
-
 // parent class
 const Item = require('./item')
 

--- a/src/request.js
+++ b/src/request.js
@@ -3,7 +3,43 @@ const moment = require('moment')
 const _merge = require('lodash.merge')
 const DB = require('@lulibrary/lag-utils').DB
 
-const fields = [
+// parent class
+const Item = require('./item')
+
+class Request extends Item {
+  constructor (requestID, requestCacheTable, region) {
+    let data = {
+      id: requestID,
+      tableName: requestCacheTable,
+      region,
+      key: 'request_id',
+      type: 'request'
+    }
+    super(data)
+  }
+
+  // populate (requestData) {
+  //   this.data = _merge(this.data, _pick(requestData, fields))
+  //   return this
+  // }
+
+  // addExpiryDate (expiry_field = 'due_date') {
+  //   if (this.data[expiry_field]) {
+  //     this.data.expiry_date = moment(this.data[expiry_field]).unix()
+  //   }
+  //   return this
+  // }
+
+  // save () {
+  //   return this.db.save(this.data)
+  // }
+
+  // delete () {
+  //   return this.db.delete({ request_id: this.request_id })
+  // }
+}
+
+Request.fields = [
   'request_id',
   'user_primary_id',
   'request_type',
@@ -24,36 +60,5 @@ const fields = [
   'resource_sharing',
   'process_status'
 ]
-
-class Request {
-  constructor (requestID, requestCacheTable, region) {
-    this.request_id = requestID
-    this.requestCacheTable = requestCacheTable
-    this.requestData = {
-      request_id: requestID
-    }
-    this.db = new DB(requestCacheTable, region)
-  }
-
-  populate (requestData) {
-    this.requestData = _merge(this.requestData, _pick(requestData, fields))
-    return this
-  }
-
-  addExpiryDate (expiry_field = 'due_date') {
-    if (this.requestData[expiry_field]) {
-      this.requestData.expiry_date = moment(this.requestData[expiry_field]).unix()
-    }
-    return this
-  }
-
-  save () {
-    return this.db.save(this.requestData)
-  }
-
-  delete () {
-    return this.db.delete({ request_id: this.request_id })
-  }
-}
 
 module.exports = Request

--- a/src/request.js
+++ b/src/request.js
@@ -12,26 +12,6 @@ class Request extends Item {
     }
     super(data)
   }
-
-  // populate (requestData) {
-  //   this.data = _merge(this.data, _pick(requestData, fields))
-  //   return this
-  // }
-
-  // addExpiryDate (expiry_field = 'due_date') {
-  //   if (this.data[expiry_field]) {
-  //     this.data.expiry_date = moment(this.data[expiry_field]).unix()
-  //   }
-  //   return this
-  // }
-
-  // save () {
-  //   return this.db.save(this.data)
-  // }
-
-  // delete () {
-  //   return this.db.delete({ request_id: this.request_id })
-  // }
 }
 
 Request.fields = [

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,59 @@
+const _pick = require('lodash.pick')
+const moment = require('moment')
+const _merge = require('lodash.merge')
+const DB = require('@lulibrary/lag-utils').DB
+
+const fields = [
+  'request_id',
+  'user_primary_id',
+  'request_type',
+  'request_sub_type',
+  'request_status',
+  'pickup_location',
+  'pickup_location_type',
+  'pickup_location_library',
+  'material_type',
+  'comment',
+  'place_in_queue',
+  'request_date',
+  'barcode',
+  'mms_id',
+  'title',
+  'author',
+  'description',
+  'resource_sharing',
+  'process_status'
+]
+
+class Request {
+  constructor (requestID, requestCacheTable, region) {
+    this.request_id = requestID
+    this.requestCacheTable = requestCacheTable
+    this.requestData = {
+      request_id: requestID
+    }
+    this.db = new DB(requestCacheTable, region)
+  }
+
+  populate (requestData) {
+    this.requestData = _merge(this.requestData, _pick(requestData, fields))
+    return this
+  }
+
+  addExpiryDate (expiry_field = 'due_date') {
+    if (this.requestData[expiry_field]) {
+      this.requestData.expiry_date = moment(this.requestData[expiry_field]).unix()
+    }
+    return this
+  }
+
+  save () {
+    return this.db.save(this.requestData)
+  }
+
+  delete () {
+    return this.db.delete({ request_id: this.request_id })
+  }
+}
+
+module.exports = Request

--- a/src/request.js
+++ b/src/request.js
@@ -2,14 +2,11 @@
 const Item = require('./item')
 
 class Request extends Item {
-  constructor (requestID, requestCacheTable, region) {
-    let data = {
-      id: requestID,
-      tableName: requestCacheTable,
-      region,
-      key: 'request_id',
-      type: 'request'
-    }
+  constructor (params) {
+    let data = params
+    data.key = 'request_id'
+    data.type = 'request'
+
     super(data)
   }
 }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -21,9 +21,9 @@ describe('request class tests', () => {
   describe('constructor tests', () => {
     it('should populate the instance with the expected parameters', () => {
       let testRequest = new Request('test', 'cachetable')
-      testRequest.request_id.should.equal('test')
-      testRequest.requestCacheTable.should.equal('cachetable')
-      testRequest.requestData.should.deep.equal({ request_id: 'test' })
+      testRequest.id.should.equal('test')
+      testRequest.tableName.should.equal('cachetable')
+      testRequest.data.should.deep.equal({ request_id: 'test' })
     })
   })
 
@@ -42,9 +42,9 @@ describe('request class tests', () => {
       }
 
       let testRequest = new Request('a request', 'a table')
-      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(requestData)
-      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.data.should.deep.equal({request_id: 'a request'})
     })
 
     it('should keep all wanted fields in the loan data', () => {
@@ -97,9 +97,9 @@ describe('request class tests', () => {
       }
 
       let testRequest = new Request('a request', 'a table', 'a region')
-      testRequest.requestData.should.deep.equal({ request_id: 'a request' })
+      testRequest.data.should.deep.equal({ request_id: 'a request' })
       testRequest.populate(input)
-      testRequest.requestData.should.deep.equal(expected)
+      testRequest.data.should.deep.equal(expected)
     })
 
     it('should overwrite existing fields if there a new values provided', () => {
@@ -124,11 +124,11 @@ describe('request class tests', () => {
       }
 
       let testRequest = new Request('a request', 'a table')
-      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(input1)
-      testRequest.requestData.should.deep.equal(expected1)
+      testRequest.data.should.deep.equal(expected1)
       testRequest.populate(input2)
-      testRequest.requestData.should.deep.equal(expected2)
+      testRequest.data.should.deep.equal(expected2)
     })
 
     it('should not remove existing fields if no new value is provided', () => {
@@ -159,11 +159,11 @@ describe('request class tests', () => {
       }
 
       let testRequest = new Request('a request', 'a table')
-      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(input1)
-      testRequest.requestData.should.deep.equal(expected1)
+      testRequest.data.should.deep.equal(expected1)
       testRequest.populate(input2)
-      testRequest.requestData.should.deep.equal(expected2)
+      testRequest.data.should.deep.equal(expected2)
     })
   })
 
@@ -173,7 +173,7 @@ describe('request class tests', () => {
     it('should not add an expiry date if the expiry field is not set', () => {
       const testRequest = new Request('a request', 'RequestCacheTable')
         .addExpiryDate()
-      testRequest.requestData.should.not.have.property('expiry_date')
+      testRequest.data.should.not.have.property('expiry_date')
     })
   })
 
@@ -185,7 +185,7 @@ describe('request class tests', () => {
       const testRequest = new Request('a request', 'request cache table')
 
       return testRequest.save().then(() => {
-        saveStub.should.have.been.calledWith(testRequest.requestData)
+        saveStub.should.have.been.calledWith(testRequest.data)
       })
     })
 

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -1,0 +1,243 @@
+const DB = require('@lulibrary/lag-utils').DB
+
+const sinon = require('sinon')
+const sandbox = sinon.sandbox.create()
+
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+chai.should()
+
+// Module under test
+const Request = require('../src/request')
+
+describe('request class tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('constructor tests', () => {
+    it('should populate the instance with the expected parameters', () => {
+      let testRequest = new Request('test', 'cachetable')
+      testRequest.request_id.should.equal('test')
+      testRequest.requestCacheTable.should.equal('cachetable')
+      testRequest.requestData.should.deep.equal({ request_id: 'test' })
+    })
+  })
+
+  describe('populate method tests', () => {
+    it('should remove unwanted fields in the request data', () => {
+      const requestData = {
+        param1: 'unwanted',
+        param2: 'also unwanted',
+        param3: {
+          this: 'is',
+          an: 'un',
+          wanted: 'param'
+        },
+        param4: true,
+        request_id: 'a request'
+      }
+
+      let testRequest = new Request('a request', 'a table')
+      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.populate(requestData)
+      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+    })
+
+    it('should keep all wanted fields in the loan data', () => {
+      const input = {
+        request_id: 'a request',
+        user_primary_id: 'a user',
+        request_type: 'a type',
+        request_sub_type: 'a sub type',
+        request_status: 'a status',
+        pickup_location: 'a location',
+        pickup_location_type: 'a location type',
+        pickup_location_library: 'a library',
+        material_type: 'a material type',
+        comment: 'a comment',
+        place_in_queue: 'a place in queue',
+        request_date: 'a data',
+        barcode: 'a barcode',
+        mms_id: 'an mms id',
+        title: 'a title',
+        author: 'an author',
+        description: 'a description',
+        resource_sharing: 'an object',
+        process_status: 'a status',
+        a_useless_param: {},
+        another_useless_param: {
+          thing: 'thing'
+        }
+      }
+
+      const expected = {
+        request_id: 'a request',
+        user_primary_id: 'a user',
+        request_type: 'a type',
+        request_sub_type: 'a sub type',
+        request_status: 'a status',
+        pickup_location: 'a location',
+        pickup_location_type: 'a location type',
+        pickup_location_library: 'a library',
+        material_type: 'a material type',
+        comment: 'a comment',
+        place_in_queue: 'a place in queue',
+        request_date: 'a data',
+        barcode: 'a barcode',
+        mms_id: 'an mms id',
+        title: 'a title',
+        author: 'an author',
+        description: 'a description',
+        resource_sharing: 'an object',
+        process_status: 'a status'
+      }
+
+      let testRequest = new Request('a request', 'a table', 'a region')
+      testRequest.requestData.should.deep.equal({ request_id: 'a request' })
+      testRequest.populate(input)
+      testRequest.requestData.should.deep.equal(expected)
+    })
+
+    it('should overwrite existing fields if there a new values provided', () => {
+      const input1 = {
+        request_id: 'a request',
+        user_primary_id: 'a user'
+      }
+
+      const expected1 = {
+        request_id: 'a request',
+        user_primary_id: 'a user'
+      }
+
+      const input2 = {
+        request_id: 'another request',
+        user_primary_id: 'another user'
+      }
+
+      const expected2 = {
+        request_id: 'another request',
+        user_primary_id: 'another user'
+      }
+
+      let testRequest = new Request('a request', 'a table')
+      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.populate(input1)
+      testRequest.requestData.should.deep.equal(expected1)
+      testRequest.populate(input2)
+      testRequest.requestData.should.deep.equal(expected2)
+    })
+
+    it('should not remove existing fields if no new value is provided', () => {
+      const input1 = {
+        request_id: 'a request',
+        user_primary_id: 'a user',
+        request_type: 'a type',
+        title: 'a book'
+      }
+
+      const expected1 = {
+        request_id: 'a request',
+        user_primary_id: 'a user',
+        request_type: 'a type',
+        title: 'a book'
+      }
+
+      const input2 = {
+        user_primary_id: 'another user',
+        request_type: 'aanother type'
+      }
+
+      const expected2 = {
+        request_id: 'a request',
+        user_primary_id: 'another user',
+        request_type: 'aanother type',
+        title: 'a book'
+      }
+
+      let testRequest = new Request('a request', 'a table')
+      testRequest.requestData.should.deep.equal({request_id: 'a request'})
+      testRequest.populate(input1)
+      testRequest.requestData.should.deep.equal(expected1)
+      testRequest.populate(input2)
+      testRequest.requestData.should.deep.equal(expected2)
+    })
+  })
+
+  describe('add expiry date method tests', () => {
+    it('should add the correct expiry date for the request')
+
+    it('should not add an expiry date if the expiry field is not set', () => {
+      const testRequest = new Request('a request', 'RequestCacheTable')
+        .addExpiryDate()
+      testRequest.requestData.should.not.have.property('expiry_date')
+    })
+  })
+
+  describe('save method tests', () => {
+    it('should call the database save method with the request data', () => {
+      const saveStub = sandbox.stub(DB.prototype, 'save')
+      saveStub.resolves(true)
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.save().then(() => {
+        saveStub.should.have.been.calledWith(testRequest.requestData)
+      })
+    })
+
+    it('should be fulfilled if DB#save resolves', () => {
+      const saveStub = sandbox.stub(DB.prototype, 'save')
+      saveStub.resolves(true)
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.save().should.eventually.be.fulfilled
+    })
+
+    it('should be rejected if DB#save is rejected', () => {
+      const saveStub = sandbox.stub(DB.prototype, 'save')
+      saveStub.rejects(new Error('Database error'))
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.save().should.eventually.be.rejectedWith('Database error')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+  })
+
+  describe('delete method tests', () => {
+    it('should call DB#delete with the correct key', () => {
+      const deleteStub = sandbox.stub(DB.prototype, 'delete')
+      deleteStub.resolves(true)
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.delete().then(() => {
+        deleteStub.should.have.been.calledWith({ request_id: 'a request' })
+      })
+    })
+
+    it('should be fulfilled if DB#delete resolves', () => {
+      const deleteStub = sandbox.stub(DB.prototype, 'delete')
+      deleteStub.resolves(true)
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.delete().should.eventually.be.fulfilled
+    })
+
+    it('should be rejected if DB#delete is rejected', () => {
+      const deleteStub = sandbox.stub(DB.prototype, 'delete')
+      deleteStub.rejects(new Error('Database error'))
+
+      const testRequest = new Request('a request', 'request cache table')
+
+      return testRequest.delete().should.eventually.be.rejectedWith('Database error')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+  })
+})

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -20,7 +20,7 @@ describe('request class tests', () => {
 
   describe('constructor tests', () => {
     it('should populate the instance with the expected parameters', () => {
-      let testRequest = new Request('test', 'cachetable')
+      let testRequest = new Request({ id: 'test', tableName: 'cachetable', region: 'a region' })
       testRequest.id.should.equal('test')
       testRequest.tableName.should.equal('cachetable')
       testRequest.data.should.deep.equal({ request_id: 'test' })
@@ -41,7 +41,7 @@ describe('request class tests', () => {
         request_id: 'a request'
       }
 
-      let testRequest = new Request('a request', 'a table')
+      let testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
       testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(requestData)
       testRequest.data.should.deep.equal({request_id: 'a request'})
@@ -96,7 +96,7 @@ describe('request class tests', () => {
         process_status: 'a status'
       }
 
-      let testRequest = new Request('a request', 'a table', 'a region')
+      let testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
       testRequest.data.should.deep.equal({ request_id: 'a request' })
       testRequest.populate(input)
       testRequest.data.should.deep.equal(expected)
@@ -123,7 +123,7 @@ describe('request class tests', () => {
         user_primary_id: 'another user'
       }
 
-      let testRequest = new Request('a request', 'a table')
+      let testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
       testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(input1)
       testRequest.data.should.deep.equal(expected1)
@@ -158,7 +158,7 @@ describe('request class tests', () => {
         title: 'a book'
       }
 
-      let testRequest = new Request('a request', 'a table')
+      let testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
       testRequest.data.should.deep.equal({request_id: 'a request'})
       testRequest.populate(input1)
       testRequest.data.should.deep.equal(expected1)
@@ -171,7 +171,7 @@ describe('request class tests', () => {
     it('should add the correct expiry date for the request')
 
     it('should not add an expiry date if the expiry field is not set', () => {
-      const testRequest = new Request('a request', 'RequestCacheTable')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
         .addExpiryDate()
       testRequest.data.should.not.have.property('expiry_date')
     })
@@ -182,7 +182,7 @@ describe('request class tests', () => {
       const saveStub = sandbox.stub(DB.prototype, 'save')
       saveStub.resolves(true)
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.save().then(() => {
         saveStub.should.have.been.calledWith(testRequest.data)
@@ -193,7 +193,7 @@ describe('request class tests', () => {
       const saveStub = sandbox.stub(DB.prototype, 'save')
       saveStub.resolves(true)
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.save().should.eventually.be.fulfilled
     })
@@ -202,7 +202,7 @@ describe('request class tests', () => {
       const saveStub = sandbox.stub(DB.prototype, 'save')
       saveStub.rejects(new Error('Database error'))
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.save().should.eventually.be.rejectedWith('Database error')
         .and.should.eventually.be.an.instanceOf(Error)
@@ -214,7 +214,7 @@ describe('request class tests', () => {
       const deleteStub = sandbox.stub(DB.prototype, 'delete')
       deleteStub.resolves(true)
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.delete().then(() => {
         deleteStub.should.have.been.calledWith({ request_id: 'a request' })
@@ -225,7 +225,7 @@ describe('request class tests', () => {
       const deleteStub = sandbox.stub(DB.prototype, 'delete')
       deleteStub.resolves(true)
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.delete().should.eventually.be.fulfilled
     })
@@ -234,7 +234,7 @@ describe('request class tests', () => {
       const deleteStub = sandbox.stub(DB.prototype, 'delete')
       deleteStub.rejects(new Error('Database error'))
 
-      const testRequest = new Request('a request', 'request cache table')
+      const testRequest = new Request({ id: 'a request', tableName: 'cachetable', region: 'a region' })
 
       return testRequest.delete().should.eventually.be.rejectedWith('Database error')
         .and.should.eventually.be.an.instanceOf(Error)

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,18 @@
 const chai = require('chai')
 chai.should()
 
+// Test data
+const Request = require('../src/request')
+
 // Module under test
 const Utils = require('../src')
 
 describe('index tests', () => {
   it('should export an object', () => {
     Utils.should.be.an('object')
+  })
+
+  it('should export a Request object matching the one exported by loan.js', () => {
+    Utils.Request.should.deep.equal(Request)
   })
 })


### PR DESCRIPTION
Adds a Loan class to the package with methods to populate with webhook data, save to the database and delete from the database.

There is also a method to add an expiry date to the Request, although this may not currently function as required due to there being no field in the Alma request body to set an expiry date from