### PR TITLE
Add Dynamoose user

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,9 @@
 extends: standard
 plugins:
   - mocha
+  - chai-friendly
 env:
   mocha: true
+rules:
+  no-unused-expressions: 0
+  chai-friendly/no-unused-expressions: 2

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # DynamoDB Local directory
 dynamodblocal
+
+# vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,3 @@ typings/
 
 # DynamoDB Local directory
 dynamodblocal
-
-# vscode
-.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,6 +512,7 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-0.8.7.tgz",
       "integrity": "sha512-TZuv+5a5tq4ZpHYgtxic72o4IJjw0fBeeLCEVS5MLDZevARmb79mIaV/AY8vKWP7wxrkRAWXIF4mfg0NHas9Vg==",
+      "dev": true,
       "requires": {
         "aws-sdk": "^2.80.0",
         "debug": "^2.6.8",
@@ -524,6 +525,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -638,6 +640,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-chai-friendly": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.1.tgz",
+      "integrity": "sha512-hkpLN7VVoGGsofZjUhcQ+sufC3FgqMJwD0DvAcRfxY1tVRyQyVsqpaKnToPHJQOrRo0FQ0fSEDwW2gr4rsNdGA==",
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.11.0",
@@ -967,7 +975,8 @@
     "hooks": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.3.2.tgz",
-      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM="
+      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -1210,11 +1219,6 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
-    "lodash.unionby": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
-      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
-    },
     "lolex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -1285,7 +1289,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -1204,6 +1209,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.unionby": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
+      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
     },
     "lolex": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,7 +512,6 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-0.8.7.tgz",
       "integrity": "sha512-TZuv+5a5tq4ZpHYgtxic72o4IJjw0fBeeLCEVS5MLDZevARmb79mIaV/AY8vKWP7wxrkRAWXIF4mfg0NHas9Vg==",
-      "dev": true,
       "requires": {
         "aws-sdk": "^2.80.0",
         "debug": "^2.6.8",
@@ -525,7 +524,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -975,8 +973,7 @@
     "hooks": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.3.2.tgz",
-      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM=",
-      "dev": true
+      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM="
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -1194,9 +1191,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.chunk": {
       "version": "4.2.0",
@@ -1289,8 +1286,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.1",
     "dynamodb-local": "0.0.21",
     "dynamoose": "^0.8.7",
+    "lodash.chunk": "^4.2.0",
     "lodash.merge": "^4.6.1",
     "lodash.pick": "^4.4.0",
+    "lodash.unionby": "^4.8.0",
     "moment": "^2.22.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "aws-sdk-mock": "^1.7.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "dynamoose": "^0.8.7",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
@@ -40,11 +42,9 @@
   "dependencies": {
     "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.1",
     "dynamodb-local": "0.0.21",
-    "dynamoose": "^0.8.7",
     "lodash.chunk": "^4.2.0",
     "lodash.merge": "^4.6.1",
     "lodash.pick": "^4.4.0",
-    "lodash.unionby": "^4.8.0",
     "moment": "^2.22.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "aws-sdk-mock": "^1.7.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "dynamoose": "^0.8.7",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-chai-friendly": "^0.4.1",
@@ -42,6 +41,7 @@
   "dependencies": {
     "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.1",
     "dynamodb-local": "0.0.21",
+    "dynamoose": "^0.8.7",
     "lodash.chunk": "^4.2.0",
     "lodash.merge": "^4.6.1",
     "lodash.pick": "^4.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   Request: require('./request'),
   LoanSchema: require('./loan-schema'),
-  RequestSchema: require('./request-schema')
+  RequestSchema: require('./request-schema'),
+  UserSchema: require('./user-schema')
 }

--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -1,0 +1,69 @@
+const dynamoose = require('dynamoose')
+const moment = require('moment')
+const _chunk = require('lodash.chunk')
+const _unionBy = require('lodash.unionby')
+
+const batchGetLimit = 25
+
+dynamoose.setDefaults({
+  create: false,
+  waitForActiveTimeout: 5000
+})
+
+const Schema = dynamoose.Schema
+
+const expiryOffset = {
+  value: 2,
+  unit: 'hours'
+}
+
+const calculateExpiry = () => {
+  return moment.add(expiryOffset.value, expiryOffset.unit).unix()
+}
+
+const userSchema = new Schema({
+  primary_id: {
+    type: String,
+    hashKey: true
+  },
+  loan_ids: [String],
+  request_ids: [String],
+  expiry_date: {
+    type: Number,
+    default: (model) => calculateExpiry(model.due_date)
+  }
+}, {})
+
+module.exports = (userTable) => {
+  if (userTable.region) {
+    dynamoose.AWS.config.update({
+      region: userTable.region
+    })
+  }
+
+  let model = dynamoose.model(userTable.name, userSchema)
+
+  model.prototype.addLoan = function (loanID) {
+    if (!this.loan_ids.includes(loanID)) {
+      this.loan_ids.push(loanID)
+    }
+  }
+
+  model.prototype.getLoanData = function (loanModel) {
+    this.loans = []
+
+    const loanIdBatches = _chunk(this.loan_ids, batchGetLimit)
+    let promises = []
+
+    loanIdBatches.forEach((batch) => {
+      const batchKeys = batch.map((loanID) => { return { loan_id: loanID } })
+      promises.push(loanModel.batchGet(batchKeys).then(loans => {
+        this.loans = this.loans.concat(loans)
+      }))
+    })
+
+    return Promise.all(promises).then(() => this.loans)
+  }
+
+  return model
+}

--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -79,14 +79,4 @@ userSchema.methods = {
   }
 }
 
-module.exports = (userTable) => {
-  if (userTable.region) {
-    dynamoose.AWS.config.update({
-      region: userTable.region
-    })
-  }
-
-  let model = dynamoose.model(userTable.name, userSchema)
-
-  return model
-}
+module.exports = (userTable) => dynamoose.model(userTable.name, userSchema)

--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -84,4 +84,4 @@ userSchema.methods = {
   }
 }
 
-module.exports = (userTable) => dynamoose.model(userTable.name, userSchema)
+module.exports = (userTable) => dynamoose.model(userTable, userSchema)

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ chai.should()
 const Request = require('../src/request')
 const RequestSchema = require('../src/request-schema')
 const LoanSchema = require('../src/loan-schema')
+const UserSchema = require('../src/user-schema')
 
 // Module under test
 const Utils = require('../src')
@@ -24,5 +25,9 @@ describe('index tests', () => {
 
   it('should export a LoanSchema object matching the one exported by loan-schema.js', () => {
     Utils.LoanSchema.should.deep.equal(LoanSchema)
+  })
+
+  it('should export a UserSchema object matching the one exported by user-schema.js', () => {
+    Utils.UserSchema.should.deep.equal(UserSchema)
   })
 })

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -1,0 +1,152 @@
+const sinon = require('sinon')
+const sandbox = sinon.sandbox.create()
+
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+const should = chai.should()
+
+const rewire = require('rewire')
+
+const Model = require('dynamoose').Model
+const LoanSchema = require('../src/loan-schema')
+
+// Module under test
+const UserSchema = rewire('../src/user-schema')
+
+const testUserTable = {
+  name: 'usertable',
+  region: 'eu-west-2'
+}
+
+const TestUserModel = UserSchema(testUserTable)
+
+describe('user schema tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('add method tests', () => {
+    it('should add a loan to the user if it does not already have the loan', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: []
+      })
+
+      testUser.addLoan('a loan')
+
+      testUser.loan_ids.should.include('a loan')
+    })
+
+    it('should not add a loan if the user already has the loan', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: ['a loan']
+      })
+
+      testUser.addLoan('a loan')
+
+      testUser.loan_ids.should.deep.equal(['a loan'])
+    })
+  })
+
+  describe('get loan data tests', () => {
+    it('should create an empty array of loans if no loan ids are present', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: []
+      })
+
+      should.not.exist(testUser.loans)
+
+      return testUser.getLoanData(null).should.eventually.deep.equal([])
+    })
+
+    it('should call batchGet on the Loan model with an array of Keys', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: ['1', '2', '3']
+      })
+
+      let testLoanModel = LoanSchema('table', 'region')
+      let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
+      batchGetStub.resolves([])
+
+      const expected = [{
+        loan_id: '1'
+      }, {
+        loan_id: '2'
+      }, {
+        loan_id: '3'
+      }]
+
+      return testUser.getLoanData(testLoanModel).then(() => {
+        batchGetStub.should.have.been.calledWith(expected)
+      })
+    })
+
+    it('should call batchGet on the Loan model twice if the number of loans is over the batchGet limit', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: new Array(30).fill(0).map((value, index) => index.toString())
+      })
+
+      let testLoanModel = LoanSchema('table', 'region')
+      let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
+      batchGetStub.resolves([])
+
+      return testUser.getLoanData(testLoanModel).then(() => {
+        batchGetStub.should.have.been.calledTwice
+      })
+    })
+
+    it('should return a populated list of loans from the model#batchGet response', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: ['1', '2', '3']
+      })
+
+      const expected = [{
+        loan_id: '1',
+        title: 'book1'
+      }, {
+        loan_id: '2',
+        title: 'book2'
+      }, {
+        loan_id: '3',
+        title: 'book3'
+      }]
+
+      let testLoanModel = LoanSchema('table', 'region')
+      let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
+      batchGetStub.resolves(expected)
+
+      return testUser.getLoanData(testLoanModel).then(() => {
+        testUser.loans.should.deep.equal(expected)
+      })
+    })
+
+    it('should fully populate the loan list if multiple batchGet requests are made', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: new Array(30).fill(0).map((value, index) => index.toString())
+      })
+
+      const return1 = testUser.loan_ids.slice(0, 25).map(id => { return { loan_id: id, title: `book ${id}` } })
+      const return2 = testUser.loan_ids.slice(25).map(id => { return { loan_id: id, title: `book ${id}` } })
+
+      const expected = testUser.loan_ids.map(id => { return { loan_id: id, title: `book ${id}` } })
+
+      let testLoanModel = LoanSchema('table', 'region')
+      let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
+      batchGetStub.onCall(0).resolves(return1)
+      batchGetStub.onCall(1).resolves(return2)
+
+      return testUser.getLoanData(testLoanModel).then(() => {
+        testUser.loans.should.deep.equal(expected)
+      })
+    })
+  })
+})

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -1,3 +1,5 @@
+const AWS_MOCK = require('aws-sdk-mock')
+
 const sinon = require('sinon')
 const sandbox = sinon.sandbox.create()
 
@@ -11,7 +13,8 @@ const should = chai.should()
 const rewire = require('rewire')
 
 const Model = require('dynamoose').Model
-// const LoanSchema = require('../src/loan-schema')
+const LoanSchema = require('../src/loan-schema')
+const RequestSchema = require('../src/request-schema')
 
 // Module under test
 const UserSchema = rewire('../src/user-schema')
@@ -28,7 +31,73 @@ describe('user schema tests', () => {
     sandbox.restore()
   })
 
+  describe('calculate expiry tests', () => {
+    const calculateExpiry = UserSchema.__get__('calculateExpiry')
+    const stubTime = 0
+
+    it('should return the current time + the amount specified in the offset', () => {
+      sandbox.stub(Date, 'now').returns(stubTime)
+
+      const offset = {
+        value: 2,
+        unit: 'hours'
+      }
+
+      const expected = stubTime + 2 * 3600
+
+      calculateExpiry(offset).should.equal(expected)
+    })
+  })
+
+  describe('model tests', () => {
+    it('should set the expiry date for record', () => {
+      const stubTime = 0
+
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: []
+      })
+
+      const putStub = sandbox.stub()
+      putStub.callsArgWith(1, null, true)
+      AWS_MOCK.mock('DynamoDB', 'putItem', putStub)
+
+      AWS_MOCK.mock('DynamoDB', 'describeTable', true)
+
+      sandbox.stub(Date, 'now').returns(stubTime)
+      const expected = stubTime + 2 * 3600
+
+      testUser.save()
+
+      testUser.expiry_date.should.equal(expected)
+    })
+  })
+
   describe('add method tests', () => {
+    it('should add a loan to the user if it does not already have the loan', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: []
+      })
+
+      testUser.add('loan_ids', 'a loan')
+
+      testUser.loan_ids.should.include('a loan')
+    })
+
+    it('should not add a loan if the user already has the loan', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: ['a loan']
+      })
+
+      testUser.add('loan_ids', 'a loan')
+
+      testUser.loan_ids.should.deep.equal(['a loan'])
+    })
+  })
+
+  describe('add loan method tests', () => {
     it('should add a loan to the user if it does not already have the loan', () => {
       let testUser = new TestUserModel({
         primary_id: 'test user',
@@ -52,6 +121,30 @@ describe('user schema tests', () => {
     })
   })
 
+  describe('add request method tests', () => {
+    it('should add a request to the user if it does not already have the loan', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: []
+      })
+
+      testUser.addRequest('a request')
+
+      testUser.request_ids.should.include('a request')
+    })
+
+    it('should not add a request if the user already has the request', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: ['a request']
+      })
+
+      testUser.addRequest('a request')
+
+      testUser.request_ids.should.deep.equal(['a request'])
+    })
+  })
+
   describe('get loan data tests', () => {
     it('should create an empty array of loans if no loan ids are present', () => {
       let testUser = new TestUserModel({
@@ -70,7 +163,7 @@ describe('user schema tests', () => {
         loan_ids: ['1', '2', '3']
       })
 
-      let testLoanModel = LoanSchema('table', 'region')
+      let testLoanModel = LoanSchema('table')
       let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
       batchGetStub.resolves([])
 
@@ -146,6 +239,104 @@ describe('user schema tests', () => {
 
       return testUser.getLoanData(testLoanModel).then(() => {
         testUser.loans.should.deep.equal(expected)
+      })
+    })
+  })
+
+  describe('get request data tests', () => {
+    it('should create an empty array of requests if no requests ids are present', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: []
+      })
+
+      should.not.exist(testUser.requests)
+
+      return testUser.getRequestData(null).should.eventually.deep.equal([])
+    })
+
+    it('should call batchGet on the Request model with an array of Keys', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: ['1', '2', '3']
+      })
+
+      let testRequestModel = RequestSchema('table')
+      let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
+      batchGetStub.resolves([])
+
+      const expected = [{
+        request_id: '1'
+      }, {
+        request_id: '2'
+      }, {
+        request_id: '3'
+      }]
+
+      return testUser.getRequestData(testRequestModel).then(() => {
+        batchGetStub.should.have.been.calledWith(expected)
+      })
+    })
+
+    it('should call batchGet on the Loan model twice if the number of requests is over the batchGet limit', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: new Array(30).fill(0).map((value, index) => index.toString())
+      })
+
+      let testRequestModel = RequestSchema('table')
+      let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
+      batchGetStub.resolves([])
+
+      return testUser.getRequestData(testRequestModel).then(() => {
+        batchGetStub.should.have.been.calledTwice
+      })
+    })
+
+    it('should return a populated list of loans from the model#batchGet response', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: ['1', '2', '3']
+      })
+
+      const expected = [{
+        loan_id: '1',
+        title: 'book1'
+      }, {
+        loan_id: '2',
+        title: 'book2'
+      }, {
+        loan_id: '3',
+        title: 'book3'
+      }]
+
+      let testRequestModel = RequestSchema('table')
+      let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
+      batchGetStub.resolves(expected)
+
+      return testUser.getRequestData(testRequestModel).then(() => {
+        testUser.requests.should.deep.equal(expected)
+      })
+    })
+
+    it('should fully populate the loan list if multiple batchGet requests are made', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: new Array(30).fill(0).map((value, index) => index.toString())
+      })
+
+      const return1 = testUser.request_ids.slice(0, 25).map(id => { return { request_id: id, title: `book ${id}` } })
+      const return2 = testUser.request_ids.slice(25).map(id => { return { request_id: id, title: `book ${id}` } })
+
+      const expected = testUser.request_ids.map(id => { return { request_id: id, title: `book ${id}` } })
+
+      let testRequestModel = RequestSchema('table')
+      let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
+      batchGetStub.onCall(0).resolves(return1)
+      batchGetStub.onCall(1).resolves(return2)
+
+      return testUser.getRequestData(testRequestModel).then(() => {
+        testUser.requests.should.deep.equal(expected)
       })
     })
   })

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -11,7 +11,7 @@ const should = chai.should()
 const rewire = require('rewire')
 
 const Model = require('dynamoose').Model
-const LoanSchema = require('../src/loan-schema')
+// const LoanSchema = require('../src/loan-schema')
 
 // Module under test
 const UserSchema = rewire('../src/user-schema')

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -161,7 +161,7 @@ describe('user schema tests', () => {
 
       should.not.exist(testUser.loans)
 
-      return testUser.getLoanData(null).then(() => {
+      return testUser.populateLoans(null).then(() => {
         testUser.loans.should.deep.equal([])
       })
     })
@@ -184,7 +184,7 @@ describe('user schema tests', () => {
         loan_id: '3'
       }]
 
-      return testUser.getLoanData(testLoanModel).then(() => {
+      return testUser.populateLoans(testLoanModel).then(() => {
         batchGetStub.should.have.been.calledWith(expected)
       })
     })
@@ -199,7 +199,7 @@ describe('user schema tests', () => {
       let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
       batchGetStub.resolves([])
 
-      return testUser.getLoanData(testLoanModel).then(() => {
+      return testUser.populateLoans(testLoanModel).then(() => {
         batchGetStub.should.have.been.calledTwice
       })
     })
@@ -225,7 +225,7 @@ describe('user schema tests', () => {
       let batchGetStub = sandbox.stub(testLoanModel, 'batchGet')
       batchGetStub.resolves(expected)
 
-      return testUser.getLoanData(testLoanModel).then(() => {
+      return testUser.populateLoans(testLoanModel).then(() => {
         testUser.loans.should.deep.equal(expected)
       })
     })
@@ -246,7 +246,7 @@ describe('user schema tests', () => {
       batchGetStub.onCall(0).resolves(return1)
       batchGetStub.onCall(1).resolves(return2)
 
-      return testUser.getLoanData(testLoanModel).then(() => {
+      return testUser.populateLoans(testLoanModel).then(() => {
         testUser.loans.should.deep.equal(expected)
       })
     })
@@ -261,7 +261,7 @@ describe('user schema tests', () => {
 
       should.not.exist(testUser.requests)
 
-      return testUser.getRequestData(null).then(() => {
+      return testUser.populateRequests(null).then(() => {
         testUser.requests.should.deep.equal([])
       })
     })
@@ -284,7 +284,7 @@ describe('user schema tests', () => {
         request_id: '3'
       }]
 
-      return testUser.getRequestData(testRequestModel).then(() => {
+      return testUser.populateRequests(testRequestModel).then(() => {
         batchGetStub.should.have.been.calledWith(expected)
       })
     })
@@ -299,7 +299,7 @@ describe('user schema tests', () => {
       let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
       batchGetStub.resolves([])
 
-      return testUser.getRequestData(testRequestModel).then(() => {
+      return testUser.populateRequests(testRequestModel).then(() => {
         batchGetStub.should.have.been.calledTwice
       })
     })
@@ -325,7 +325,7 @@ describe('user schema tests', () => {
       let batchGetStub = sandbox.stub(testRequestModel, 'batchGet')
       batchGetStub.resolves(expected)
 
-      return testUser.getRequestData(testRequestModel).then(() => {
+      return testUser.populateRequests(testRequestModel).then(() => {
         testUser.requests.should.deep.equal(expected)
       })
     })
@@ -346,7 +346,7 @@ describe('user schema tests', () => {
       batchGetStub.onCall(0).resolves(return1)
       batchGetStub.onCall(1).resolves(return2)
 
-      return testUser.getRequestData(testRequestModel).then(() => {
+      return testUser.populateRequests(testRequestModel).then(() => {
         testUser.requests.should.deep.equal(expected)
       })
     })

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -153,7 +153,9 @@ describe('user schema tests', () => {
 
       should.not.exist(testUser.loans)
 
-      return testUser.getLoanData(null).should.eventually.deep.equal([])
+      return testUser.getLoanData(null).then(() => {
+        testUser.loans.should.deep.equal([])
+      })
     })
 
     it('should call batchGet on the Loan model with an array of Keys', () => {
@@ -251,7 +253,9 @@ describe('user schema tests', () => {
 
       should.not.exist(testUser.requests)
 
-      return testUser.getRequestData(null).should.eventually.deep.equal([])
+      return testUser.getRequestData(null).then(() => {
+        testUser.requests.should.deep.equal([])
+      })
     })
 
     it('should call batchGet on the Request model with an array of Keys', () => {

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -185,7 +185,7 @@ describe('user schema tests', () => {
       return testUser.getData(testLoanModel, testUser.loan_ids, 'loan_id')
         .then((loans) => {
           return loans.forEach((loan) => {
-            loan.should.be.an.instanceOf(Model)
+            loan.should.be.an.instanceOf(testLoanModel)
           })
         })
     })

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -12,7 +12,6 @@ const should = chai.should()
 
 const rewire = require('rewire')
 
-const Model = require('dynamoose').Model
 const LoanSchema = require('../src/loan-schema')
 const RequestSchema = require('../src/request-schema')
 

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -18,10 +18,7 @@ const RequestSchema = require('../src/request-schema')
 // Module under test
 const UserSchema = rewire('../src/user-schema')
 
-const testUserTable = {
-  name: 'usertable',
-  region: 'eu-west-2'
-}
+const testUserTable = 'usertable'
 
 const TestUserModel = UserSchema(testUserTable)
 

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -152,45 +152,6 @@ describe('user schema tests', () => {
     })
   })
 
-  describe('get data method tests', function () {
-    before(() => {
-      AWS_MOCK.mock('DynamoDB', 'describeTable', { Table: { TableStatus: 'ACTIVE' } })
-    })
-
-    after(() => {
-      AWS_MOCK.restore('DynamoDB')
-    })
-
-    it('should return an array of instances of the supplied model', () => {
-      const LocalUserModel = UserSchema('cache-api-userCacheTable-dev')
-      let testUser = new LocalUserModel({
-        primary_id: 'test user',
-        loan_ids: ['loan1', 'loan2']
-      })
-
-      AWS_MOCK.mock('DynamoDB', 'batchGetItem', { Responses: { 'cache-api-loanCacheTable-dev': [
-        {
-          loan_id: 'loan1'
-        },
-        {
-          loan_id: 'loan2'
-        }
-      ] } })
-
-      let testLoanModel = LoanSchema('cache-api-loanCacheTable-dev')
-
-      // return dynamo.describeTable({ TableName: 'cache-api-loanCacheTable-dev' }).promise().then(console.log)
-      // return testLoanModel.create({ loan_id: 'loan1' })
-
-      return testUser.getData(testLoanModel, testUser.loan_ids, 'loan_id')
-        .then((loans) => {
-          return loans.forEach((loan) => {
-            loan.should.be.an.instanceOf(testLoanModel)
-          })
-        })
-    })
-  })
-
   describe('get loan data tests', () => {
     it('should create an empty array of loans if no loan ids are present', () => {
       let testUser = new TestUserModel({


### PR DESCRIPTION
This adds a Dynamoose User schema for User data from Alma, which includes methods to add Loans and Requests to the User, and to retrieve all User's Requests/Loans from the cache.