### PR TITLE
Change User Schema types

### DIFF
--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -25,8 +25,14 @@ const userSchema = new Schema({
     type: String,
     hashKey: true
   },
-  loan_ids: [String],
-  request_ids: [String],
+  loan_ids: {
+    type: 'list',
+    list: [String]
+  },
+  request_ids: {
+    type: 'list',
+    list: [String]
+  },
   expiry_date: {
     type: Number,
     default: (model) => calculateExpiry(expiryOffset)


### PR DESCRIPTION
This changes the types of the `loan_ids` and `request_ids` fields on the User Schema to be DynamoDB list objects instead of sets. This allows an empty array to be created as (e.g.) `loan_ids: []`.