### PR TITLE
User delete Loan and Request methods

### DIFF
--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -91,7 +91,20 @@ userSchema.methods = {
       this[field].push(value)
     }
     return this
+  },
+
+  delete: function (field, value) {
+    this[field] = this[field].filter(v => v !== value)
+  },
+
+  deleteLoan: function (loanID) {
+    return this.delete('loan_ids', loanID)
+  },
+
+  deleteRequest: function (requestID) {
+    return this.delete('request_ids', requestID)
   }
+
 }
 
 module.exports = (userTable) => dynamoose.model(userTable, userSchema)

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -351,4 +351,62 @@ describe('user schema tests', () => {
       })
     })
   })
+
+  describe('delete method tests', () => {
+    it('should remove all matching values from the array', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: new Array(30).fill(0).map((value, index) => (index % 3).toString())
+      })
+
+      let expected = new Array(20).fill(0).map((value, index) => (index % 2).toString())
+
+      testUser.delete('request_ids', '2')
+
+      testUser.request_ids.should.deep.equal(expected)
+    })
+
+    it('should not alter the array if no matching value is present', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: new Array(30).fill(0).map((value, index) => (index % 3).toString())
+      })
+
+      let expected = new Array(30).fill(0).map((value, index) => (index % 3).toString())
+
+      testUser.delete('request_ids', '4')
+
+      testUser.request_ids.should.deep.equal(expected)
+    })
+  })
+
+  describe('delete loan method tests', () => {
+    it('should call User#delete with the loan ID and the `loan_ids` field', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        loan_ids: new Array(30).fill(0).map((value, index) => (index % 3).toString())
+      })
+
+      const deleteStub = sandbox.stub(testUser, 'delete')
+
+      testUser.deleteLoan('loan')
+
+      deleteStub.should.have.been.calledWithExactly('loan_ids', 'loan')
+    })
+  })
+
+  describe('delete request method tests', () => {
+    it('should call User#delete with the request ID and the `request_ids` field', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        request_ids: new Array(30).fill(0).map((value, index) => (index % 3).toString())
+      })
+
+      const deleteStub = sandbox.stub(testUser, 'delete')
+
+      testUser.deleteRequest('request')
+
+      deleteStub.should.have.been.calledWithExactly('request_ids', 'request')
+    })
+  })
 })


### PR DESCRIPTION
This adds `deleteLoan` and `deleteRequest` methods to the User class, to be used when removing Loan and Request records from the cache.