### PR TITLE
Request Expiry

### DIFF
--- a/src/default-expiry.js
+++ b/src/default-expiry.js
@@ -1,0 +1,4 @@
+module.exports = {
+  type: Number,
+  default: () => Math.floor(Date.now() / 1000) + 2 * 7 * 24 * 60 * 60
+}

--- a/src/default-expiry.js
+++ b/src/default-expiry.js
@@ -1,4 +1,6 @@
+const moment = require('moment')
+
 module.exports = {
   type: Number,
-  default: () => Math.floor(Date.now() / 1000) + 2 * 7 * 24 * 60 * 60
+  default: () => moment().add(2, 'weeks').unix()
 }

--- a/src/fee-schema.js
+++ b/src/fee-schema.js
@@ -1,6 +1,7 @@
 const dynamoose = require('dynamoose')
 
 const getValid = require('./get-valid')
+const defaultExpiry = require('./default-expiry')
 
 dynamoose.setDefaults({
   create: false,
@@ -32,10 +33,7 @@ const feeSchema = new Schema({
     type: 'list',
     list: [Object]
   },
-  expiry_date: {
-    type: Number,
-    default: () => Math.floor(Date.now() / 1000) + 2 * 7 * 24 * 60 * 60
-  }
+  expiry_date: defaultExpiry
 }, {
   useDocumentTypes: true
 })

--- a/src/get-valid.js
+++ b/src/get-valid.js
@@ -1,9 +1,9 @@
 const moment = require('moment')
 
-module.exports = function (ID) {
+module.exports = function (ID, expiryField = 'expiry_date') {
   return this.get(ID)
     .then(user => {
-      return (user && user.expiry_date >= moment().unix())
+      return (user && user[expiryField] >= moment().unix())
         ? user
         : null
     })

--- a/src/request-schema.js
+++ b/src/request-schema.js
@@ -1,6 +1,7 @@
 const dynamoose = require('dynamoose')
 
 const getValid = require('./get-valid')
+const defaultExpiry = require('./default-expiry')
 
 dynamoose.setDefaults({
   create: false,
@@ -45,10 +46,7 @@ const requestSchema = new Schema({
   description: String,
   resource_sharing: String,
   process_status: String,
-  record_expiry_date: {
-    type: Number,
-    default: () => Math.floor(Date.now() / 1000) + 2 * 7 * 24 * 60 * 60
-  }
+  record_expiry_date: defaultExpiry
 }, {
   useDocumentTypes: true
 })

--- a/src/request-schema.js
+++ b/src/request-schema.js
@@ -1,5 +1,7 @@
 const dynamoose = require('dynamoose')
 
+const getValid = require('./get-valid')
+
 dynamoose.setDefaults({
   create: false,
   waitForActiveTimeout: 5000
@@ -42,9 +44,15 @@ const requestSchema = new Schema({
   author: String,
   description: String,
   resource_sharing: String,
-  process_status: String
+  process_status: String,
+  record_expiry_date: {
+    type: Number,
+    default: () => Math.floor(Date.now() / 1000) + 2 * 7 * 24 * 60 * 60
+  }
 }, {
   useDocumentTypes: true
 })
+
+requestSchema.statics.getValid = (requestID) => getValid(requestID, 'record_expiry_date')
 
 module.exports = (tableName) => dynamoose.model(tableName, requestSchema)


### PR DESCRIPTION
This adds a `record_expiry_date` field to the Request schema to avoid conflicting with the existing `expiry_date` field documented in the Alma `user_request` specification. The `record_expiry_date` is set by default to two weeks from the creation of the request record.

This also adds a `getValid` method to the Request model, to retrieve only requests which have not expired. This also modifies the `getValid` module method to accept an optional expiry field, to accommodate the Request schema having a non standard expiry field.