### PR TITLE
Add User array defaults and Fee methods

### DIFF
--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -29,11 +29,18 @@ const userSchema = new Schema({
   },
   loan_ids: {
     type: 'list',
-    list: [String]
+    list: [String],
+    default: []
   },
   request_ids: {
     type: 'list',
-    list: [String]
+    list: [String],
+    default: []
+  },
+  fee_ids: {
+    type: 'list',
+    list: [String],
+    default: []
   },
   expiry_date: {
     type: Number,
@@ -90,6 +97,10 @@ userSchema.methods = {
     return this.add('request_ids', requestID)
   },
 
+  addFee: function (feeID) {
+    return this.add('fee_ids', feeID)
+  },
+
   add: function (field, value) {
     if (!this[field].includes(value)) {
       this[field].push(value)
@@ -108,6 +119,10 @@ userSchema.methods = {
 
   deleteRequest: function (requestID) {
     return this.deleteItem('request_ids', requestID)
+  },
+
+  deleteFee: function (feeID) {
+    return this.deleteItem('fee_ids', feeID)
   }
 
 }

--- a/test/fee-schema-test.js
+++ b/test/fee-schema-test.js
@@ -127,6 +127,37 @@ describe('fee schema tests', function () {
         })
     })
 
+    it('should allow for empty transaction arrays', () => {
+      const dateStub = sandbox.stub(Date, 'now')
+      dateStub.returns(0)
+
+      const testID = uuid()
+      const testFeeData = {
+        id: testID,
+        user_primary_id: 'a user',
+        transactions: []
+      }
+
+      const expected = {
+        id: testID,
+        user_primary_id: 'a user',
+        transactions: [],
+        expiry_date: 2 * 7 * 24 * 60 * 60
+      }
+
+      return new Promise((resolve, reject) => {
+        TestFeeModel.create(testFeeData, (err, data) => {
+          err ? reject(err) : resolve(data)
+        })
+      })
+        .then(() => {
+          return TestFeeModel.get(testID)
+            .then((data) => {
+              Object.assign({}, data).should.deep.equal(expected)
+            })
+        })
+    })
+
     it('should remove parameters not in the schema', () => {
       const dateStub = sandbox.stub(Date, 'now')
       dateStub.returns(0)

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -112,6 +112,27 @@ describe('user schema tests', function () {
     })
   })
 
+  describe('schema tests', () => {
+    it('should default the loan_ids, request_ids and fee_ids to empty arrays', () => {
+      const testUserID = uuid()
+      sandbox.stub(Date, 'now').returns(0)
+
+      return new TestUserModel({
+        primary_id: testUserID
+      }).save()
+        .then(() => {
+          TestUserModel.get(testUserID)
+            .should.eventually.deep.equal({
+              primary_id: testUserID,
+              expiry_date: 2 * 60 * 60,
+              loan_ids: [],
+              request_ids: [],
+              fee_ids: []
+            })
+        })
+    })
+  })
+
   describe('getValid method tests', () => {
     it('should return a record with an expiry date in the future', () => {
       const stubTime = 0
@@ -209,7 +230,7 @@ describe('user schema tests', function () {
   })
 
   describe('add request method tests', () => {
-    it('should add a request to the user if it does not already have the loan', () => {
+    it('should add a request to the user if it does not already have the request', () => {
       let testUser = new TestUserModel({
         primary_id: 'test user',
         request_ids: []
@@ -229,6 +250,30 @@ describe('user schema tests', function () {
       testUser.addRequest('a request')
 
       testUser.request_ids.should.deep.equal(['a request'])
+    })
+  })
+
+  describe('add fee method tests', () => {
+    it('should add a fee to the user if it does not already have the fee', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        fee_ids: []
+      })
+
+      testUser.addFee('a fee')
+
+      testUser.fee_ids.should.include('a fee')
+    })
+
+    it('should not add a fee if the user already has the fee', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        fee_ids: ['a fee']
+      })
+
+      testUser.addFee('a fee')
+
+      testUser.fee_ids.should.deep.equal(['a fee'])
     })
   })
 

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -544,4 +544,19 @@ describe('user schema tests', function () {
       deleteStub.should.have.been.calledWithExactly('request_ids', 'request')
     })
   })
+
+  describe('delete fee method tests', () => {
+    it('should call User#deleteItem with the fee ID and the `fee_ids` field', () => {
+      let testUser = new TestUserModel({
+        primary_id: 'test user',
+        fee_ids: new Array(30).fill(0).map((value, index) => (index % 3).toString())
+      })
+
+      const deleteStub = sandbox.stub(testUser, 'deleteItem')
+
+      testUser.deleteFee('test-fee')
+
+      deleteStub.should.have.been.calledWithExactly('fee_ids', 'test-fee')
+    })
+  })
 })


### PR DESCRIPTION
This adds default empty arrays on the User Schema for the `loan_ids`, `request_ids` and `fee_ids` fields.
This also adds `addFee` and `deleteFee` instance methods on the User model.