### PR TITLE
Fix RequestModel#getValid

### DIFF
--- a/src/request-schema.js
+++ b/src/request-schema.js
@@ -51,6 +51,8 @@ const requestSchema = new Schema({
   useDocumentTypes: true
 })
 
-requestSchema.statics.getValid = (requestID) => getValid(requestID, 'record_expiry_date')
+requestSchema.statics.getValid = function (requestID) {
+  return getValid.call(this, requestID, 'record_expiry_date')
+}
 
 module.exports = (tableName) => dynamoose.model(tableName, requestSchema)

--- a/test/request-schema-test.js
+++ b/test/request-schema-test.js
@@ -167,5 +167,20 @@ describe('request schema tests', function () {
           getValidStub.should.have.been.calledWith(testRequestId, correctExpiryField)
         })
     })
+
+    it('should call the getValid method with the correct `this` context', () => {
+      const testRequestId = uuid()
+
+      const getValidStub = sandbox.stub()
+      getValidStub.resolves()
+      wires.push(
+        RequestSchema.__set__('getValid', getValidStub)
+      )
+
+      return TestRequestModel.getValid(testRequestId)
+        .then(() => {
+          getValidStub.should.have.been.calledOn(TestRequestModel)
+        })
+    })
   })
 })


### PR DESCRIPTION
This fixes the `getValid` function on the request model, changing it to call the `getValid` module method with the correct `this` value.