### PR TITLE
Fix Fee Schema

### DIFF
--- a/src/fee-schema.js
+++ b/src/fee-schema.js
@@ -15,9 +15,27 @@ const feeSchema = new Schema({
     type: String,
     hashKey: true
   },
-  user_primary_id: String,
-  type: String,
-  status: String,
+  type: {
+    type: 'map',
+    map: {
+      value: String,
+      desc: String
+    }
+  },
+  status: {
+    type: 'map',
+    map: {
+      value: String,
+      desc: String
+    }
+  },
+  user_primary_id: {
+    type: 'map',
+    map: {
+      value: String,
+      link: String
+    }
+  },
   balance: Number,
   remaining_vat_amount: Number,
   original_amount: Number,
@@ -25,9 +43,16 @@ const feeSchema = new Schema({
   creation_time: Number,
   status_time: Number,
   comment: String,
-  owner: String,
+  owner: {
+    type: 'map',
+    map: {
+      value: String,
+      desc: String
+    }
+  },
   title: String,
   barcode: String,
+  link: String,
   bursar_transaction_id: String,
   transactions: {
     type: 'list',

--- a/test/fee-schema-test.js
+++ b/test/fee-schema-test.js
@@ -59,9 +59,18 @@ describe('fee schema tests', function () {
       const testID = uuid()
       const testFeeData = {
         id: testID,
-        user_primary_id: 'a user',
-        type: 'a type',
-        status: 'a status',
+        user_primary_id: {
+          value: 'a user',
+          link: 'http://a.link.for.user'
+        },
+        type: {
+          value: 'a type',
+          desc: 'this is a type'
+        },
+        status: {
+          value: 'a status',
+          desc: 'this is a status'
+        },
         balance: 123456,
         remaining_vat_amount: 12345,
         original_amount: 100.00,
@@ -69,9 +78,13 @@ describe('fee schema tests', function () {
         creation_time: 1234567890,
         status_time: 9876543210,
         comment: 'a comment',
-        owner: 'an owner',
+        owner: {
+          value: 'a owner',
+          desc: 'this is an owner'
+        },
         title: 'a title',
         barcode: 'a barcode',
+        link: 'a link',
         bursar_transaction_id: 'a transaction id',
         transactions: [{
           transaction: '1',
@@ -87,9 +100,18 @@ describe('fee schema tests', function () {
 
       const expected = {
         id: testID,
-        user_primary_id: 'a user',
-        type: 'a type',
-        status: 'a status',
+        user_primary_id: {
+          value: 'a user',
+          link: 'http://a.link.for.user'
+        },
+        type: {
+          value: 'a type',
+          desc: 'this is a type'
+        },
+        status: {
+          value: 'a status',
+          desc: 'this is a status'
+        },
         balance: 123456,
         remaining_vat_amount: 12345,
         original_amount: 100.00,
@@ -97,9 +119,13 @@ describe('fee schema tests', function () {
         creation_time: 1234567890,
         status_time: 9876543210,
         comment: 'a comment',
-        owner: 'an owner',
+        owner: {
+          value: 'a owner',
+          desc: 'this is an owner'
+        },
         title: 'a title',
         barcode: 'a barcode',
+        link: 'a link',
         bursar_transaction_id: 'a transaction id',
         transactions: [{
           transaction: '1',
@@ -134,13 +160,19 @@ describe('fee schema tests', function () {
       const testID = uuid()
       const testFeeData = {
         id: testID,
-        user_primary_id: 'a user',
+        user_primary_id: {
+          value: 'a user',
+          link: 'a link'
+        },
         transactions: []
       }
 
       const expected = {
         id: testID,
-        user_primary_id: 'a user',
+        user_primary_id: {
+          value: 'a user',
+          link: 'a link'
+        },
         transactions: [],
         expiry_date: 2 * 7 * 24 * 60 * 60
       }


### PR DESCRIPTION
This fixes the Fee schema to match the response of the Alma API `/users/<userID>/fees/<feeID>` endpoint, from which the Fee records are created.