### PR TITLE
Make User IDs Lowercase

### DIFF
--- a/src/fee-schema.js
+++ b/src/fee-schema.js
@@ -32,7 +32,10 @@ const feeSchema = new Schema({
   user_primary_id: {
     type: 'map',
     map: {
-      value: String,
+      value: {
+        type: String,
+        lowercase: true
+      },
       link: String
     }
   },

--- a/src/loan-schema.js
+++ b/src/loan-schema.js
@@ -23,7 +23,10 @@ const loanSchema = new Schema({
     type: String,
     hashKey: true
   },
-  user_id: String,
+  user_id: {
+    type: String,
+    lowercase: true
+  },
   renewable: Boolean,
   call_number: String,
   loan_status: String,

--- a/src/request-schema.js
+++ b/src/request-schema.js
@@ -15,7 +15,10 @@ const requestSchema = new Schema({
     type: String,
     hashKey: true
   },
-  user_primary_id: String,
+  user_primary_id: {
+    type: String,
+    lowercase: true
+  },
   request_type: String,
   request_sub_type: {
     type: 'map',

--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -25,7 +25,8 @@ const calculateExpiry = (offset) => {
 const userSchema = new Schema({
   primary_id: {
     type: String,
-    hashKey: true
+    hashKey: true,
+    lowercase: true
   },
   loan_ids: {
     type: 'list',

--- a/test/fee-schema-test.js
+++ b/test/fee-schema-test.js
@@ -217,5 +217,37 @@ describe('fee schema tests', function () {
           })
         })
     })
+
+    it('should force the user_id value to lowercase', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      const userUUID = uuid()
+      const upcaseUserID = `TEST_USER_ID_${userUUID.toUpperCase()}`
+      const lowercaseUserID = `test_user_id_${userUUID.toLowerCase()}`
+      const testFeeID = uuid()
+
+      const testLoanData = {
+        id: testFeeID,
+        user_primary_id: {
+          value: upcaseUserID
+        }
+      }
+
+      return new TestFeeModel(testLoanData).save()
+        .then(() => {
+          return docClient.get({
+            Key: { id: testFeeID },
+            TableName: 'feeTable'
+          }).promise().then(res => {
+            res.Item.should.deep.equal({
+              id: testFeeID,
+              user_primary_id: {
+                value: lowercaseUserID
+              },
+              expiry_date: 2 * 7 * 24 * 60 * 60
+            })
+          })
+        })
+    })
   })
 })

--- a/test/loan-schema-test.js
+++ b/test/loan-schema-test.js
@@ -165,6 +165,32 @@ describe('loan schema tests', function () {
         })
     })
 
+    it('should force the user_id to lowercase', () => {
+      const userUUID = uuid()
+      const upcaseUserID = `TEST_USER_ID_${userUUID.toUpperCase()}`
+      const lowercaseUserID = `test_user_id_${userUUID.toLowerCase()}`
+      const testLoanID = uuid()
+
+      const testLoanData = {
+        loan_id: testLoanID,
+        user_id: upcaseUserID
+      }
+
+      return new TestLoanModel(testLoanData).save()
+        .then(() => {
+          return docClient.get({
+            Key: { loan_id: testLoanID },
+            TableName: 'loanTable'
+          }).promise().then(res => {
+            res.Item.should.deep.equal({
+              loan_id: testLoanID,
+              user_id: lowercaseUserID,
+              expiry_date: 0
+            })
+          })
+        })
+    })
+
     describe('getValid method tests', () => {
       it('should return a record with an expiry date in the future', () => {
         const stubTime = 0

--- a/test/request-schema-test.js
+++ b/test/request-schema-test.js
@@ -149,6 +149,34 @@ describe('request schema tests', function () {
           })
         })
     })
+
+    it('should force the user_id to lowercase', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      const userUUID = uuid()
+      const upcaseUserID = `TEST_USER_ID_${userUUID.toUpperCase()}`
+      const lowercaseUserID = `test_user_id_${userUUID.toLowerCase()}`
+      const testRequestID = uuid()
+
+      const testLoanData = {
+        request_id: testRequestID,
+        user_primary_id: upcaseUserID
+      }
+
+      return new TestRequestModel(testLoanData).save()
+        .then(() => {
+          return docClient.get({
+            Key: { request_id: testRequestID },
+            TableName: 'requestTable'
+          }).promise().then(res => {
+            res.Item.should.deep.equal({
+              request_id: testRequestID,
+              user_primary_id: lowercaseUserID,
+              record_expiry_date: 2 * 7 * 24 * 60 * 60
+            })
+          })
+        })
+    })
   })
 
   describe('getValid method tests', () => {

--- a/test/user-schema-test.js
+++ b/test/user-schema-test.js
@@ -121,13 +121,65 @@ describe('user schema tests', function () {
         primary_id: testUserID
       }).save()
         .then(() => {
-          TestUserModel.get(testUserID)
-            .should.eventually.deep.equal({
-              primary_id: testUserID,
-              expiry_date: 2 * 60 * 60,
-              loan_ids: [],
-              request_ids: [],
-              fee_ids: []
+          return TestUserModel.get(testUserID)
+            .then(res => {
+              Object.assign({}, res).should.deep.equal({
+                primary_id: testUserID,
+                loan_ids: [],
+                request_ids: [],
+                fee_ids: [],
+                expiry_date: 7200
+              })
+            })
+        })
+    })
+
+    it('should save user IDs as lowercase', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      const testUUID = uuid()
+      const testUserID = `test_user_${testUUID.toLowerCase()}`
+      const testUpcaseID = `TEST_USER_${testUUID.toUpperCase()}`
+
+      return new TestUserModel({
+        primary_id: testUpcaseID,
+        loan_ids: []
+      }).save()
+        .then(res => {
+          return TestUserModel.get(testUserID)
+            .then(res => {
+              Object.assign({}, res).should.deep.equal({
+                primary_id: testUserID,
+                loan_ids: [],
+                request_ids: [],
+                fee_ids: [],
+                expiry_date: 7200
+              })
+            })
+        })
+    })
+
+    it('should match a queried uppercase ID to a lowercase ID on a record', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      const testUUID = uuid()
+      const testUserID = `test_user_${testUUID.toLowerCase()}`
+      const testUpcaseID = `TEST_USER_${testUUID.toUpperCase()}`
+
+      return new TestUserModel({
+        primary_id: testUserID,
+        loan_ids: []
+      }).save()
+        .then(() => {
+          return TestUserModel.get(testUpcaseID)
+            .then(res => {
+              Object.assign({}, res).should.deep.equal({
+                primary_id: testUserID,
+                loan_ids: [],
+                request_ids: [],
+                fee_ids: [],
+                expiry_date: 7200
+              })
             })
         })
     })


### PR DESCRIPTION
This changes all schemas to force user IDs to be lowercase, to ensure User cache records are not duplicated for upper and lower case user IDs. 