### PR TITLE
Queued User schema

### DIFF
--- a/src/calculate-expiry.js
+++ b/src/calculate-expiry.js
@@ -1,0 +1,5 @@
+const moment = require('moment')
+
+module.exports = (offset) => {
+  return moment().add(offset.value, offset.unit).unix()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ module.exports = {
   LoanSchema: require('./loan-schema'),
   RequestSchema: require('./request-schema'),
   FeeSchema: require('./fee-schema'),
-  UserSchema: require('./user-schema')
+  UserSchema: require('./user-schema'),
+  QueuedUserSchema: require('./queued-user-schema')
 }

--- a/src/queued-user-schema.js
+++ b/src/queued-user-schema.js
@@ -1,0 +1,31 @@
+const dynamoose = require('dynamoose')
+
+const getValid = require('./get-valid')
+const calculateExpiry = require('./calculate-expiry')
+
+dynamoose.setDefaults({
+  create: false,
+  waitForActiveTimeout: 5000
+})
+
+const Schema = dynamoose.Schema
+
+const expiryOffset = {
+  value: 5,
+  unit: 'minutes'
+}
+
+const queuedUserSchema = new Schema({
+  primary_id: {
+    type: String,
+    hashKey: true
+  },
+  expiry_date: {
+    type: Number,
+    default: () => calculateExpiry(expiryOffset)
+  }
+})
+
+queuedUserSchema.statics.getValid = getValid
+
+module.exports = (userTable) => dynamoose.model(userTable, queuedUserSchema)

--- a/src/user-schema.js
+++ b/src/user-schema.js
@@ -1,5 +1,4 @@
 const dynamoose = require('dynamoose')
-const moment = require('moment')
 const _chunk = require('lodash.chunk')
 
 const getValid = require('./get-valid')
@@ -18,9 +17,7 @@ const expiryOffset = {
   unit: 'hours'
 }
 
-const calculateExpiry = (offset) => {
-  return moment().add(offset.value, offset.unit).unix()
-}
+const calculateExpiry = require('./calculate-expiry')
 
 const userSchema = new Schema({
   primary_id: {

--- a/test/queued-user-schema-test.js
+++ b/test/queued-user-schema-test.js
@@ -1,0 +1,84 @@
+const AWS = require('aws-sdk')
+
+// **** DynamoDB
+const dynamo = new AWS.DynamoDB({ endpoint: 'http://127.0.0.1:8000', region: 'eu-west-2' })
+
+const dynamoose = require('dynamoose')
+dynamoose.AWS.config.update({
+  region: 'eu-west-2'
+})
+dynamoose.local()
+const DynamoLocal = require('dynamodb-local')
+const DynamoLocalPort = 8000
+// ****
+
+// **** Test Libraries
+const sinon = require('sinon')
+const sandbox = sinon.sandbox.create()
+
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+chai.should()
+// ****
+
+const uuid = require('uuid/v4')
+const rewire = require('rewire')
+
+// Module under test
+const QueuedSchema = rewire('../src/queued-user-schema')
+
+const testQueuedTable = 'queued_user_table'
+
+const TestQueuedModel = QueuedSchema(testQueuedTable)
+
+describe('user schema tests', function () {
+  this.timeout(5000)
+  before(function () {
+    this.timeout(25000)
+    process.env.AWS_ACCESS_KEY_ID = 'key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'key2'
+    return require('./dynamodb-local')('queued_user_table', 'primary_id')
+      .then(() => {
+        return dynamo.listTables().promise().then((data) => {
+          console.log('Tables:', data.TableNames)
+        })
+      })
+  })
+
+  after(() => {
+    console.log('Tests complete')
+    delete process.env.AWS_ACCESS_KEY_ID
+    delete process.env.AWS_SECRET_ACCESS_KEY
+    DynamoLocal.stop(DynamoLocalPort)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('model tests', () => {
+    it('should set a default expiry of 5 minutes', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      const testQueuedID = `test_queued_${uuid()}`
+
+      return TestQueuedModel.create({
+        primary_id: testQueuedID
+      }, {
+        overwrite: true
+      })
+        .then(() => {
+          return TestQueuedModel.get(testQueuedID)
+            .then(res => {
+              Object.assign({}, res).should.deep.equal({
+                primary_id: testQueuedID,
+                expiry_date: 5 * 60
+              })
+            })
+        })
+    })
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ const RequestSchema = require('../src/request-schema')
 const LoanSchema = require('../src/loan-schema')
 const FeeSchema = require('../src/fee-schema')
 const UserSchema = require('../src/user-schema')
+const QueuedUserSchema = require('../src/queued-user-schema')
 
 // Module under test
 const Utils = require('../src')
@@ -29,5 +30,9 @@ describe('index tests', () => {
 
   it('should export a UserSchema object matching the one exported by user-schema.js', () => {
     Utils.UserSchema.should.deep.equal(UserSchema)
+  })
+
+  it('should export a QueuedUserSchema object matching the one exported by queued-user-schema.js', () => {
+    Utils.QueuedUserSchema.should.deep.equal(QueuedUserSchema)
   })
 })


### PR DESCRIPTION
This adds a Schema for Queued Users, to provide a system for flagging users as being queued for bulk updates to prevent them being queued several times in a short time frame.

The default expiry for queued user records is set to 5 minutes.