### PR TITLE
Fix Fee Schema Types

### DIFF
--- a/src/fee-schema.js
+++ b/src/fee-schema.js
@@ -43,8 +43,8 @@ const feeSchema = new Schema({
   remaining_vat_amount: Number,
   original_amount: Number,
   original_vat_amount: Number,
-  creation_time: Number,
-  status_time: Number,
+  creation_time: String,
+  status_time: String,
   comment: String,
   owner: {
     type: 'map',

--- a/test/fee-schema-test.js
+++ b/test/fee-schema-test.js
@@ -75,8 +75,8 @@ describe('fee schema tests', function () {
         remaining_vat_amount: 12345,
         original_amount: 100.00,
         original_vat_amount: 99,
-        creation_time: 1234567890,
-        status_time: 9876543210,
+        creation_time: 'a time',
+        status_time: 'another time',
         comment: 'a comment',
         owner: {
           value: 'a owner',
@@ -116,8 +116,8 @@ describe('fee schema tests', function () {
         remaining_vat_amount: 12345,
         original_amount: 100.00,
         original_vat_amount: 99,
-        creation_time: 1234567890,
-        status_time: 9876543210,
+        creation_time: 'a time',
+        status_time: 'another time',
         comment: 'a comment',
         owner: {
           value: 'a owner',


### PR DESCRIPTION
This fixes the types of `creation_time` and `status_time` on the Fee schema, changing them from `Number` to `String`